### PR TITLE
Whoops, Scalaz 7.1 version isn't in a release yet, just SNAPSHOT.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ libraryDependencies ++= {
     "com.github.julien-truffaut" %% "monocle-macro" % monocleVersion,
     "org.spire-math" %% "spire" % spireVersion,
     "org.scalaz.stream" %% "scalaz-stream" % scalazStreamVersion,
-    "org.pelotom" %% "effectful" % "1.0.1"
+    "org.pelotom" %% "effectful" % "1.1-SNAPSHOT"
   )
 }
 


### PR DESCRIPTION
This commit:
https://github.com/pelotom/effectful/commit/2256ee2f305a993fd70ecc3cc7aa02e161457199
is just in master / SNAPSHOT.

1.0.1 throws a ClassCastException if you try to use it with 7.1. Sorry about that - shoulda tested locally first. Hopefully -SNAPSHOT is ok? Could bug him to publish a new release if not.
