### PR TITLE
Sanitized input

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,9 @@ libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   "org.http4s" %% "http4s-client" % "0.15.0a",
   "org.json4s" %% "json4s-native" % "3.5.0",
-  "com.google.guava" % "guava" % "18.0"
+  "com.google.guava" % "guava" % "18.0",
+  "org.scalactic" %% "scalactic" % "3.0.1",
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 )
 
 autoCompilerPlugins := true

--- a/src/main/scala/org/multibot/InterpretersHandler.scala
+++ b/src/main/scala/org/multibot/InterpretersHandler.scala
@@ -4,12 +4,28 @@ import org.json4s.native.JsonMethods._
 import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
 
+/** This allows users to write code blocks in
+  *  gitter that get parsed correctly here */
+object InputSanitizer {
+  def sanitize(in: String): String = {
+    val tripleBackquoted = "^```(.*)```$".r
+    val singleBackquoted = "^`(.*)`$".r
+
+    in match {
+      case tripleBackquoted(s) => s
+      case singleBackquoted(s) => s
+      case s => s
+    }
+  }
+}
+
 case class InterpretersHandler(cache: InterpretersCache, http: HttpHandler, sendLines: (String, String) => Unit) {
   private var pythonSession = "" //todo
   def serve(implicit msg: Msg): Unit = msg.message match {
     case Cmd("!" :: m :: Nil) => sendLines(msg.channel, cache.scalaInterpreter(msg.channel) { (si, cout) =>
       import scala.tools.nsc.interpreter.Results._
-      si interpret m match {
+
+      si interpret InputSanitizer.sanitize(m) match {
         case Success => cout.toString.replaceAll("(?m:^res[0-9]+: )", "")
         case Error => cout.toString.replaceAll("^<console>:[0-9]+: ", "")
         case Incomplete => "error: unexpected EOF found, incomplete expression"

--- a/src/main/scala/org/multibot/InterpretersHandler.scala
+++ b/src/main/scala/org/multibot/InterpretersHandler.scala
@@ -6,7 +6,7 @@ import org.json4s.JsonDSL._
 
 /** This allows users to write code blocks in
   *  gitter that get parsed correctly here */
-object InputSanitizer {
+object GitterInputSanitizer {
   def sanitize(in: String): String = {
     val tripleBackquoted = "^```(.*)```$".r
     val singleBackquoted = "^`(.*)`$".r
@@ -25,7 +25,7 @@ case class InterpretersHandler(cache: InterpretersCache, http: HttpHandler, send
     case Cmd("!" :: m :: Nil) => sendLines(msg.channel, cache.scalaInterpreter(msg.channel) { (si, cout) =>
       import scala.tools.nsc.interpreter.Results._
 
-      si interpret InputSanitizer.sanitize(m) match {
+      si interpret GitterInputSanitizer.sanitize(m) match {
         case Success => cout.toString.replaceAll("(?m:^res[0-9]+: )", "")
         case Error => cout.toString.replaceAll("^<console>:[0-9]+: ", "")
         case Incomplete => "error: unexpected EOF found, incomplete expression"

--- a/src/main/scala/org/multibot/Multibot.scala
+++ b/src/main/scala/org/multibot/Multibot.scala
@@ -13,8 +13,8 @@ object Cmd {
   def unapply(s: String) = if (s.contains(' ')) Some(s.split(" ", 2).toList) else None
 }
 
-case class Multibot(messageSanitizer: String => Array[String], cache: InterpretersCache,
-    botname: String, channels: List[String], settings: Builder[PircBotX] => Builder[PircBotX] = identity) {
+case class Multibot(outputSanitizer: String => Array[String], cache: InterpretersCache,
+                    botname: String, channels: List[String], settings: Builder[PircBotX] => Builder[PircBotX] = identity) {
 
   val LAMBDABOT = "lambdabot"
   val ADMINS = List("imeredith", "lopex", "tpolecat", "OlegYch")
@@ -37,7 +37,7 @@ case class Multibot(messageSanitizer: String => Array[String], cache: Interprete
       def sendLines(channel: String, message: String) = {
         println(message)
 
-        messageSanitizer(message).foreach(m => {
+        outputSanitizer(message).foreach(m => {
             if (channel == sender) e.respond(m)
             else e.getBot.getUserChannelDao.getChannel(channel).send().message(m)
         })

--- a/src/main/scala/org/multibot/Multibot.scala
+++ b/src/main/scala/org/multibot/Multibot.scala
@@ -13,8 +13,13 @@ object Cmd {
   def unapply(s: String) = if (s.contains(' ')) Some(s.split(" ", 2).toList) else None
 }
 
-case class Multibot(outputSanitizer: String => Array[String], cache: InterpretersCache,
-                    botname: String, channels: List[String], settings: Builder[PircBotX] => Builder[PircBotX] = identity) {
+case class Multibot(
+   inputSanitizer: String => String,
+   outputSanitizer: String => Array[String],
+   cache: InterpretersCache,
+   botname: String,
+   channels: List[String],
+   settings: Builder[PircBotX] => Builder[PircBotX] = identity) {
 
   val LAMBDABOT = "lambdabot"
   val ADMINS = List("imeredith", "lopex", "tpolecat", "OlegYch")
@@ -42,7 +47,7 @@ case class Multibot(outputSanitizer: String => Array[String], cache: Interpreter
             else e.getBot.getUserChannelDao.getChannel(channel).send().message(m)
         })
       }
-      def interpreters = InterpretersHandler(cache, httpHandler, sendLines)
+      def interpreters = InterpretersHandler(cache, httpHandler, sendLines, inputSanitizer)
       def admin = AdminHandler(e.getBot.getNick + ":", ADMINS, _ => (), _ => (), sendLines) //todo
       DieOn.error {
         val msg = Msg(channel, sender, e.getMessage)

--- a/src/main/scala/org/multibot/Multibottest.scala
+++ b/src/main/scala/org/multibot/Multibottest.scala
@@ -25,7 +25,10 @@ object Multibottest {
         .filter(_.nonEmpty)
         .take(NUMLINES)
 
-  val ircMultibot = Multibot(ircOutputSanitizer, cache, if (PRODUCTION) "multibot_" else "multibot__",
+  val ircMultibot = Multibot(
+    ircOutputSanitizer,
+    cache,
+    if (PRODUCTION) "multibot_" else "multibot__",
     if (PRODUCTION)
       List("#clojure.pl", "#scala.pl", "#scala", "#scalaz", "#scala-fr", "#lift", "#playframework",
         "#bostonpython", "#fp-in-scala", "#CourseraProgfun", "#shapeless", "#akka", "#sbt", "#scala-monocle")

--- a/src/main/scala/org/multibot/Multibottest.scala
+++ b/src/main/scala/org/multibot/Multibottest.scala
@@ -9,7 +9,7 @@ object Multibottest {
 
   val NUMLINES = 5
 
-  def gitterSanitizer(message: String): Array[String] =
+  def gitterOutputSanitizer(message: String): Array[String] =
     message
       .replace("\r", "")
       .replace("`", "\'")
@@ -18,14 +18,14 @@ object Multibottest {
       .take(NUMLINES)
       .map(m => s"```$m```")
 
-  def ircSanitizer(message: String): Array[String] =
+  def ircOutputSanitizer(message: String): Array[String] =
     message
         .replace("\r", "")
         .split("\n")
         .filter(_.nonEmpty)
         .take(NUMLINES)
 
-  val ircMultibot = Multibot(ircSanitizer, cache, if (PRODUCTION) "multibot_" else "multibot__",
+  val ircMultibot = Multibot(ircOutputSanitizer, cache, if (PRODUCTION) "multibot_" else "multibot__",
     if (PRODUCTION)
       List("#clojure.pl", "#scala.pl", "#scala", "#scalaz", "#scala-fr", "#lift", "#playframework",
         "#bostonpython", "#fp-in-scala", "#CourseraProgfun", "#shapeless", "#akka", "#sbt", "#scala-monocle")
@@ -34,7 +34,7 @@ object Multibottest {
   )
 
   val gitterMultibot = Multibot(
-    messageSanitizer = gitterSanitizer,
+    outputSanitizer = gitterOutputSanitizer,
     cache = cache,
     botname = if (PRODUCTION) "multibot1" else "multibot2",
     channels = if (PRODUCTION) List("#scala/scala", "#sbt/sbt") else List("#OlegYch/multibot"),

--- a/src/main/scala/org/multibot/Multibottest.scala
+++ b/src/main/scala/org/multibot/Multibottest.scala
@@ -26,6 +26,7 @@ object Multibottest {
         .take(NUMLINES)
 
   val ircMultibot = Multibot(
+    identity
     ircOutputSanitizer,
     cache,
     if (PRODUCTION) "multibot_" else "multibot__",
@@ -37,6 +38,7 @@ object Multibottest {
   )
 
   val gitterMultibot = Multibot(
+    GitterInputSanitizer.sanitize
     outputSanitizer = gitterOutputSanitizer,
     cache = cache,
     botname = if (PRODUCTION) "multibot1" else "multibot2",

--- a/src/test/scala/org/multibot/InputSanitizerTest.scala
+++ b/src/test/scala/org/multibot/InputSanitizerTest.scala
@@ -1,0 +1,25 @@
+package org.multibot
+
+import org.scalatest.{Assertion, FlatSpec}
+
+class InputSanitizerTest extends FlatSpec {
+
+  def ensureSanitizedInput(in: String, expected: String): Assertion =
+    assert(InputSanitizer.sanitize(in) === expected)
+
+  def ensureNoSanitization(in: String) : Assertion =
+    ensureSanitizedInput(in, in)
+
+  "Inputs" should "be sanitized" in {
+    ensureSanitizedInput("```foo```", "foo")
+    ensureSanitizedInput("`foo`", "foo")
+
+    // I have no idea why anyone would do this, but make sure the result is expected
+    ensureSanitizedInput("````foo````", "`foo`")
+    ensureSanitizedInput("``foo``", "`foo`")
+  }
+
+  it should "not be sanitized" in {
+    ensureNoSanitization("foo")
+  }
+}

--- a/src/test/scala/org/multibot/InputSanitizerTest.scala
+++ b/src/test/scala/org/multibot/InputSanitizerTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.{Assertion, FlatSpec}
 class InputSanitizerTest extends FlatSpec {
 
   def ensureSanitizedInput(in: String, expected: String): Assertion =
-    assert(InputSanitizer.sanitize(in) === expected)
+    assert(GitterInputSanitizer.sanitize(in) === expected)
 
   def ensureNoSanitization(in: String) : Assertion =
     ensureSanitizedInput(in, in)


### PR DESCRIPTION
This allows gitter users to specify inputs in the fashion:

! ```List[Int]()```

Instead of

! List[Int]()